### PR TITLE
Support dynamic variables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@
 //! ```
 //! use menu_rs::{Menu, MenuOption};
 //!
+//! let my_variable: u32 = 157;
+//!
 //! fn action_1() {
 //!     println!("action 1")
 //! }
@@ -27,6 +29,7 @@
 //!     MenuOption::new("Option 2", || action_2(42)),
 //!     MenuOption::new("Option 3", || action_3("example", 3.14)),
 //!     MenuOption::new("Option 4", action_4),
+//!     MenuOption::new("Option 5", move || action_2(my_variable)),
 //! ]);
 //!
 //! menu.show();


### PR DESCRIPTION
It's now possible to have menu options that catch variables. Example:


```rust
use menu_rs::{Menu, MenuOption};

fn main() {
    let my_variable: u32 = 42;

    fn action(val: u32) {
        println!("Action with number {}", val)
    }

    let menu = Menu::new(vec![MenuOption::new("Option 1", move || {
        action(my_variable)
    })]);
    menu.show();
}
```

https://github.com/NFSS10/menu_rs/assets/22588915/1c243f6b-a398-4aad-9f09-1da6729c829a

